### PR TITLE
Add developer communication section for Zulip

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -25,4 +25,19 @@ A web interface for particle transport simulation codes.
 | User documentation | :octocat: [docs repo](https://github.com/yaptide/docs) |
 | Developer Documentation | :octocat: [For Developers repo](https://github.com/yaptide/for_developers) |
 
+## 💬 Developer Communication via Zulip
 
+We use [Zulip](https://zulip.com/) as our main chat platform for developer communication, discussion on development plans, issues, and pull requests. 
+
+### Joining the Yaptide Zulip Organization
+
+You can join our Zulip chat using this invite link:  
+[https://yaptide.zulipchat.com/join/nyulh3q2idqmepo7jpsoy3jz/](https://yaptide.zulipchat.com/join/nyulh3q2idqmepo7jpsoy3jz/)
+
+- New contributors joining via this link are admitted as **Guests** with limited permissions to read and participate in a few introductory channels.
+- To become full **Members** with broader access and posting rights, guests need to be manually promoted by the core team after demonstrating active participation or contribution.
+- This "Guest → Member" policy helps maintain quality and prevents spam, while allowing open and inclusive community growth.
+
+Feel free to introduce yourself in the #introductions channel once you join. Welcome aboard!
+
+---


### PR DESCRIPTION
Added section for developer communication via Zulip, including joining instructions and membership policy.